### PR TITLE
Allow configuration of user and group

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 door_open_command: '/home/pi/door-open.sh'
 ble_keykeeper_dir: '/home/pi/ble_keykeeper'
+ble_keykeeper_user: 'pi'
+ble_keykeeper_group: 'pi'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,17 +5,17 @@
     state: directory
     mode: '0755'
 
-- name: Ensure group pi exists
+- name: Ensure group exists
   ansible.builtin.group:
-    name: pi
+    name: "{{ ble_keykeeper_group }}"
     state: present
 
 - name: Copy files
   ansible.builtin.copy:
     src: "{{ item }}"
     dest: "{{ble_keykeeper_dir}}"
-    owner: pi
-    group: pi
+    owner: "{{ ble_keykeeper_user }}"
+    group: "{{ ble_keykeeper_group }}"
     mode: '0644'
   with_items:
     - "ble_helpers.py"
@@ -34,24 +34,24 @@
   ansible.builtin.copy:
     src: "ble_gen_coin.py"
     dest: "{{ble_keykeeper_dir}}"
-    owner: pi
-    group: pi
+    owner: "{{ ble_keykeeper_user }}"
+    group: "{{ ble_keykeeper_group }}"
     mode: '0744'
 
 - name: Template main executable
   ansible.builtin.template:
     src: ble_keykeeper.py
     dest: "{{ble_keykeeper_dir}}"
-    owner: pi
-    group: pi
+    owner: "{{ ble_keykeeper_user }}"
+    group: "{{ ble_keykeeper_group }}"
     mode: '0744'
 
 - name: Template service file
   ansible.builtin.template:
     src: ble-keykeeper.service
     dest: /etc/systemd/system
-    owner: pi
-    group: pi
+    owner: "{{ ble_keykeeper_user }}"
+    group: "{{ ble_keykeeper_group }}"
     mode: '0644'
 
 - name: Make sure pip3 is installed


### PR DESCRIPTION
This enhancement allows to set the user and group for the ble_keykeeper installation, allowing us to move away from the `pi` user, as suggested by the Raspberry Pi Foundation and enforced by recent Raspbian releases.

- [x] Testing